### PR TITLE
Entity and response updates

### DIFF
--- a/src/Plaid/Auth/GetAccountInfoResponse.cs
+++ b/src/Plaid/Auth/GetAccountInfoResponse.cs
@@ -27,7 +27,27 @@ namespace Acklann.Plaid.Auth
         /// </summary>
         /// <value>The numbers.</value>
         [JsonProperty("numbers")]
-        public AccountIdentifier[] Numbers { get; set; }
+        public AccountIdentifiers Numbers { get; set; }
+
+        /// <summary>
+        /// Seperates account types into ACH and EFT types.
+        /// </summary>
+        public struct AccountIdentifiers
+        {
+            /// <summary>
+            /// Gets or sets an array of ACH account numbers.
+            /// </summary>
+            /// <value>The array of ACH numbers.</value>
+            [JsonProperty("ach")]
+            public AccountIdentifier[] ACH { get; set; }
+
+            /// <summary>
+            /// Gets or sets an array of EFT account numbers.
+            /// </summary>
+            /// <value>The array of EFT numbers.</value>
+            [JsonProperty("eft")]
+            public AccountIdentifier[] EFT { get; set; }
+        }
 
         /// <summary>
         /// Represents the bank account and routing numbers associated with an <see cref="Entity.Item"/>’s checking and savings accounts.

--- a/src/Plaid/Entity/Transaction.cs
+++ b/src/Plaid/Entity/Transaction.cs
@@ -61,6 +61,26 @@ namespace Acklann.Plaid.Entity
         public float Amount { get; set; }
 
         /// <summary>
+        /// The ISO currency code of the transaction, either USD or CAD. Always null if unofficial_currency_code is non-null.
+        /// </summary>
+        /// <value>The ISO currency code.</value>
+        [JsonProperty("iso_currency_code")]
+        public string IsoCurrencyCode { get; set; }
+
+        /// <summary>
+        /// The unofficial currency code associated with the transaction. Always null if iso_currency_code is non-null.
+        /// </summary>
+        /// <value>The unofficial currency code.</value>
+        [JsonProperty("unofficial_currency_code")]
+        public string UnofficialCurrencyCode { get; set; }
+
+        /// <summary>
+        /// Gets the currency code from either IsoCurrencyCode or UnofficialCurrencyCode. If non-null, IsoCurrencyCode is returned, else if non-null, UnofficialCurrencyCode, else null is returned.
+        /// </summary>
+        /// <value>Either available currency code.</value>
+        public string CurrencyCode => IsoCurrencyCode ?? UnofficialCurrencyCode ?? null;
+
+        /// <summary>
         /// Gets or sets the date of the transaction.
         /// </summary>
         /// <value>The date.</value>


### PR DESCRIPTION
This PR addresses 2 issues:
1. `Transaction` model was missing currency codes
2. `GetAccountInfoResponse.Numbers` needed to be a struct with lists for ACH and EFT transaction types.