### PR TITLE
Fix AccountInfo request and responses.

### DIFF
--- a/src/Plaid/Auth/GetAccountInfoRequest.cs
+++ b/src/Plaid/Auth/GetAccountInfoRequest.cs
@@ -11,6 +11,23 @@ namespace Acklann.Plaid.Auth
     /// <seealso cref="Acklann.Plaid.RequestBase" />
     public class GetAccountInfoRequest : RequestBase
     {
+        
+        /// <summary>
+        /// Gets or sets the options attached to the request
+        /// </summary>
+        /// <value>The account ids.</value>
+        [JsonProperty("options")]
+        public GetAccountInfoOptions Options { get; set; }
+    }
+
+    /// <summary>
+    /// The container object for options associated with a GetAccountInfoRequest.
+    /// </summary>
+    /// <remarks>
+    /// This is outside the GetAccountInfoRequest class because it is required to build the request.
+    /// </remarks>
+    public struct GetAccountInfoOptions
+    {
         /// <summary>
         /// Gets or sets the list of account_ids to retrieve for the Item. Note: An error will be returned if a provided account_id is not associated with the Item.
         /// </summary>

--- a/src/Plaid/Auth/GetAccountInfoResponse.cs
+++ b/src/Plaid/Auth/GetAccountInfoResponse.cs
@@ -39,20 +39,20 @@ namespace Acklann.Plaid.Auth
             /// </summary>
             /// <value>The array of ACH numbers.</value>
             [JsonProperty("ach")]
-            public AccountIdentifier[] ACH { get; set; }
+            public AchAccountNumbers[] ACH { get; set; }
 
             /// <summary>
             /// Gets or sets an array of EFT account numbers.
             /// </summary>
             /// <value>The array of EFT numbers.</value>
             [JsonProperty("eft")]
-            public AccountIdentifier[] EFT { get; set; }
+            public EtfAccountNumbers[] EFT { get; set; }
         }
 
         /// <summary>
-        /// Represents the bank account and routing numbers associated with an <see cref="Entity.Item"/>’s checking and savings accounts.
+        /// Represents the bank account and routing numbers associated with an ACH account on a item.
         /// </summary>
-        public struct AccountIdentifier
+        public struct AchAccountNumbers
         {
             /// <summary>
             /// Gets or sets the plaid account identifier.
@@ -81,6 +81,40 @@ namespace Acklann.Plaid.Auth
             /// <value>The wire routing number.</value>
             [JsonProperty("wire_routing")]
             public string WireRoutingNumber { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the bank account and institution/branch associated with an EFT account on a item.
+        /// </summary>
+        public struct EtfAccountNumbers
+        {
+            /// <summary>
+            /// Gets or sets the Plaid account ID associated with the account numbers.
+            /// </summary>
+            /// <value>The account identifier.</value>
+            [JsonProperty("account_id")]
+            public string AccountId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the EFT account number for the account.
+            /// </summary>
+            /// <value>The account number.</value>
+            [JsonProperty("account")]
+            public string AccountNumber { get; set; }
+
+            /// <summary>
+            /// Gets or sets the EFT institution number for the account.
+            /// </summary>
+            /// <value>The institution identifier.</value>
+            [JsonProperty("institution")]
+            public string Institution { get; set; }
+
+            /// <summary>
+            /// Gets or sets the EFT branch number for the account.
+            /// </summary>
+            /// <value>The branch number.</value>
+            [JsonProperty("branch")]
+            public string Branch { get; set; }
         }
     }
 }


### PR DESCRIPTION
This PR fixes two issues related to `PlaidClient.FetchAccountInfoAsync`:
1. The request now contains the required `options` field (that contains the `account_ids` list)
2. The response now splits `numbers` field into `ACH` and `EFT` types.