### PR TITLE
Add function to get `accounts/get` endpoint

### DIFF
--- a/src/Plaid/PlaidClient.cs
+++ b/src/Plaid/PlaidClient.cs
@@ -153,6 +153,16 @@ namespace Acklann.Plaid
         /* Balance */
 
         /// <summary>
+        /// Retrieve high-level information about all accounts associated with an <see cref="Entity.Item"/>.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>Task&lt;Balance.GetAccountResponse&gt;.</returns>
+        public Task<Balance.GetAccountResponse> FetchAccountAsync(Balance.GetAccountRequest request)
+        {
+            return PostAsync<Balance.GetAccountResponse>("accounts/get", request);
+        }
+
+        /// <summary>
         ///  Retrieves the real-time balance for each of an <see cref="Entity.Item"/>’s accounts.
         /// </summary>
         /// <param name="request">The request.</param>


### PR DESCRIPTION
This endpoint gives basic information about an `Item`. This can be used to get information for accounts that do not support the auth product/endpoints (used by `FetchAccountInfoAsync`).

Closes https://github.com/Ackara/Plaid.NET/issues/12