### PR TITLE
Expose full `/transactions/get` response

### DIFF
--- a/src/Plaid/Transactions/GetTransactionsResponse.cs
+++ b/src/Plaid/Transactions/GetTransactionsResponse.cs
@@ -23,5 +23,19 @@ namespace Acklann.Plaid.Transactions
         /// <value>The transactions.</value>
         [JsonProperty("transactions")]
         public Transaction[] Transactions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item.
+        /// </summary>
+        /// <value>The item.</value>
+        [JsonProperty("item")]
+        public Item Item { get; set; }
+
+        /// <summary>
+        /// Gets or sets the accounts.
+        /// </summary>
+        /// <value>The accounts.</value>
+        [JsonProperty("accounts")]
+        public Account[] Accounts { get; set; }
     }
 }


### PR DESCRIPTION
The `/transactions/get` response includes a description of the item & a list of connected accounts. This change exposes those values in the response object.