### PR TITLE
Fix BACS and International numbers

### DIFF
--- a/src/Plaid/Auth/GetAccountInfoResponse.cs
+++ b/src/Plaid/Auth/GetAccountInfoResponse.cs
@@ -56,7 +56,7 @@ namespace Acklann.Plaid.Auth
             /// </summary>
             /// <value>The array of international numbers.</value>
             [JsonProperty("international")]
-            public EtfAccountNumbers[] International { get; set; }
+            public InternationalAccountNumbers[] International { get; set; }
 
             /// <summary>
             /// Gets or sets an array of BACS account numbers.
@@ -64,7 +64,7 @@ namespace Acklann.Plaid.Auth
             /// </summary>
             /// <value>The array of BACS numbers.</value>
             [JsonProperty("bacs")]
-            public EtfAccountNumbers[] BACS { get; set; }
+            public BacsAccountNumbers[] BACS { get; set; }
         }
 
         /// <summary>
@@ -133,6 +133,60 @@ namespace Acklann.Plaid.Auth
             /// <value>The branch number.</value>
             [JsonProperty("branch")]
             public string Branch { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the bank account and routing numbers associated with an international account on a item.
+        /// </summary>
+        public struct InternationalAccountNumbers
+        {
+            /// <summary>
+            /// Gets or sets the plaid account identifier.
+            /// </summary>
+            /// <value>The account identifier.</value>
+            [JsonProperty("account_id")]
+            public string AccountId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the International Bank Account Number for the account.
+            /// </summary>
+            /// <value>The International Bank Account Number (IBAN).</value>
+            [JsonProperty("iban")]
+            public string Iban { get; set; }
+
+            /// <summary>
+            /// Gets or sets the Bank Identifier Code for the account.
+            /// </summary>
+            /// <value>The Bank Identifier Code (BIC)</value>
+            [JsonProperty("bic")]
+            public string Bic { get; set; }
+        }
+
+        /// <summary>
+        /// Represents the bank account and routing numbers associated with an ACH account on a item.
+        /// </summary>
+        public struct BacsAccountNumbers
+        {
+            /// <summary>
+            /// Gets or sets the plaid account identifier.
+            /// </summary>
+            /// <value>The account identifier.</value>
+            [JsonProperty("account_id")]
+            public string AccountId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the BACS account number for the account.
+            /// </summary>
+            /// <value>The BACS account number.</value>
+            [JsonProperty("account")]
+            public string AccountNumber { get; set; }
+
+            /// <summary>
+            /// Gets or sets the BACS sort code for the account.
+            /// </summary>
+            /// <value>The BACS sort code.</value>
+            [JsonProperty("sort_code")]
+            public string RoutingNumber { get; set; }
         }
     }
 }

--- a/tests/Plaid.MSTest/Helper.cs
+++ b/tests/Plaid.MSTest/Helper.cs
@@ -19,15 +19,32 @@ namespace Acklann.Plaid
             ClientId = _plaid["client_id"].Value<string>();
             PublicKey = _plaid["public_key"].Value<string>();
             AccessToken = _plaid?["access_token"]?.Value<string>();
+            IntlAccessToken = _plaid?["intl_access_token"]?.Value<string>();
         }
 
-        public static readonly string ClientId, Secret, AccessToken, PublicKey;
+        public static readonly string ClientId, Secret, AccessToken, IntlAccessToken, PublicKey;
 
         public static TRequest UseDefaults<TRequest>(this TRequest request)
         {
             PropertyInfo[] properties = request.GetType().GetTypeInfo().GetRuntimeProperties().ToArray();
             setProperty(nameof(Institution.SearchRequest.PublicKey), PublicKey);
             setProperty(nameof(RequestBase.AccessToken), AccessToken);
+            setProperty(nameof(RequestBase.ClientId), ClientId);
+            setProperty(nameof(RequestBase.Secret), Secret);
+            return request;
+
+            void setProperty(string name, object value)
+            {
+                PropertyInfo target = properties.FirstOrDefault(p => p.Name == name);
+                if (target != null) target.SetValue(request, value);
+            }
+        }
+
+        public static TRequest UseIntlDefaults<TRequest>(this TRequest request)
+        {
+            PropertyInfo[] properties = request.GetType().GetTypeInfo().GetRuntimeProperties().ToArray();
+            setProperty(nameof(Institution.SearchRequest.PublicKey), PublicKey);
+            setProperty(nameof(RequestBase.AccessToken), IntlAccessToken);
             setProperty(nameof(RequestBase.ClientId), ClientId);
             setProperty(nameof(RequestBase.Secret), Secret);
             return request;

--- a/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
+++ b/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
@@ -158,6 +158,27 @@ namespace Acklann.Plaid.Tests
         }
 
         [TestMethod]
+        public void FetchAccountInfoAsync_International_Bacs_should_retrieve_the_routing_numbers_of_an_user_accounts()
+        {
+            // Arrange
+            var sut = new PlaidClient(Environment.Sandbox);
+            var request = new Auth.GetAccountInfoRequest()
+            {
+            }.UseIntlDefaults();
+
+            // Act
+            var result = sut.FetchAccountInfoAsync(request).Result;
+
+            // Assert
+            result.IsSuccessStatusCode.ShouldBeTrue();
+            result.RequestId.ShouldNotBeNullOrEmpty();
+            result.Accounts.Length.ShouldBeGreaterThan(0);
+            result.Numbers.International.Length.ShouldBeGreaterThan(0);
+            result.Numbers.BACS.Length.ShouldBeGreaterThan(0);
+            result.Item.ShouldNotBeNull();
+        }
+
+        [TestMethod]
         public void FetchUserIdentityAsync_should_retrieve_the_personal_info_of_an_user()
         {
             // Arrange


### PR DESCRIPTION
This PR fixes the BACS & International account number response types.

I had to create an international sandbox token to test this - this should be placed in `intl_access_token` in `secrets.json`. This may not be the desired way to test this; a more correct solution would be to refactor the tests to use tokens for specific institutions and billed products, which would clear up the current ambiguities.