### PR TITLE
Add support for refreshing an access token if the item has expired

### DIFF
--- a/src/Plaid/Management/CreatePublicTokenRequest.cs
+++ b/src/Plaid/Management/CreatePublicTokenRequest.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+    /// <summary>
+    /// Represents a request for plaid's '/item/public_token/create' endpoint. Create a public_token from an access_token for use with Plaid LInk's update mode.
+    /// </summary>
+    /// <seealso cref="Acklann.Plaid.SerializableContent" />
+    public class CreatePublicTokenRequest : SerializableContent
+    {
+        /// <summary>
+        /// Gets or sets the access_token.
+        /// </summary>
+        /// <value>The access token.</value>
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        /// <value>The client identifier.</value>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the secret.
+        /// </summary>
+        /// <value>The secret.</value>
+        [JsonProperty("secret")]
+        public string Secret { get; set; }
+    }
+}

--- a/src/Plaid/Management/CreatePublicTokenResponse.cs
+++ b/src/Plaid/Management/CreatePublicTokenResponse.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+    /// <summary>
+    /// Represents a response from plaid's '/item/public_token/create' endpoint. Create a public_token from an access_token for use with Plaid LInk's update mode.
+    /// </summary>
+    /// <seealso cref="Acklann.Plaid.ResponseBase" />
+    public class CreatePublicTokenResponse : ResponseBase
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Entity.Item"/> identifier.
+        /// </summary>
+        /// <value>The item identifier.</value>
+        [JsonProperty("item_id")]
+        public string ItemId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the public token.
+        /// </summary>
+        /// <value>The public token.</value>
+        [JsonProperty("public_token")]
+        public string PublicToken { get; set; }
+    }
+}

--- a/src/Plaid/PlaidClient.cs
+++ b/src/Plaid/PlaidClient.cs
@@ -85,6 +85,16 @@ namespace Acklann.Plaid
         /// </summary>
         /// <param name="request">The request.</param>
         /// <returns>Task&lt;Management.ExchangeTokenResponse&gt;.</returns>
+        public Task<Management.CreatePublicTokenResponse> CreatePublicTokenAsync(Management.CreatePublicTokenRequest request)
+        {
+            return PostAsync<Management.CreatePublicTokenResponse>("item/public_token/create", request);
+        }
+
+        /// <summary>
+        /// Exchanges a Link public_token for an API access_token.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <returns>Task&lt;Management.ExchangeTokenResponse&gt;.</returns>
         public Task<Management.ExchangeTokenResponse> ExchangeTokenAsync(Management.ExchangeTokenRequest request)
         {
             return PostAsync<Management.ExchangeTokenResponse>("item/public_token/exchange", request);

--- a/tests/Plaid.Demo/Controllers/HomeController.cs
+++ b/tests/Plaid.Demo/Controllers/HomeController.cs
@@ -31,6 +31,21 @@ namespace Acklann.Plaid.Demo.Controllers
             return Ok(result);
         }
 
+        [HttpPost]
+        public IActionResult GetPublicToken(Environment environment)
+        {
+            var client = new PlaidClient(environment);
+            var result = client.CreatePublicTokenAsync(new CreatePublicTokenRequest()
+            {
+                Secret = _credentials.Secret,
+                ClientId = _credentials.ClientId,
+                AccessToken = _credentials.AccessToken,
+            }).Result;
+            System.Diagnostics.Debug.WriteLine($"public_token: '{result.PublicToken}'");
+
+            return Ok(result);
+        }
+
         #region Private Members
 
         private Middleware.PlaidCredentials _credentials;

--- a/tests/Plaid.Demo/Views/Home/Index.cshtml
+++ b/tests/Plaid.Demo/Views/Home/Index.cshtml
@@ -35,6 +35,7 @@
             </div>
 
             <button data-bind="click: showPlaidLink">Link Account</button>
+            <button data-bind="click: refreshToken">Refresh Token</button>
         </div>
     </div>
 </div>
@@ -131,6 +132,47 @@
                     }
                 });
                 handler.open();
+            };
+
+            self.refreshToken = async function () {
+                app.post(("/home/getpublictoken?environment=" + self.environment()), {}, function (result) {
+                    var handler = Plaid.create({
+                        clientName: 'Plaid Walkthrough Demo',
+                        env: self.environment().toLowerCase(),
+                        key: self.publicKey(),
+                        product: self.products(),
+                        webhook: 'https://requestb.in',/* Optional, use webhooks to get transaction and error updates */
+                        token: result.public_token,
+                        onLoad: function () {
+                            // Optional, called when Link loads
+                        },
+                        onSuccess: function (public_token, metadata) {
+                            console.log("success!");
+                        },
+                        onExit: function (err, metadata) {
+                            // The user exited the Link flow.
+                            if (err != null) {
+                                // The user encountered a Plaid API error prior to exiting.
+                            }
+                            // metadata contains information about the institution
+                            // that the user selected and the most recent API request IDs.
+                            // Storing this information can be helpful for support.
+                        },
+                        onEvent: function (eventName, metadata) {
+                            // Optionally capture Link flow events, streamed through
+                            // this callback as your users connect an Item to Plaid.
+                            // For example:
+                            // eventName = "TRANSITION_VIEW"
+                            // metadata  = {
+                            //   link_session_id: "123-abc",
+                            //   mfa_type:        "questions",
+                            //   timestamp:       "2017-09-14T14:42:19.350Z",
+                            //   view_name:       "MFA",
+                            // }
+                        }
+                    });
+                    handler.open();
+                });
             };
         }
 


### PR DESCRIPTION
If the item has expired (changed password, MFA update, etc.), then the access token must be refreshed. This does not change the original token, but does reset the Plaid side access to the institution. This adds the API for getting a new public token from an access token, and updates the demo app to show how to use the new public token to trigger a refresh.