### PR TITLE
Add link token create

### DIFF
--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Entity
+{
+    /// <summary>
+    /// Represents a user.
+    /// </summary>
+    public class User
+    {
+        /// <summary>
+        /// Gets or sets the client user id.
+        /// </summary>
+        /// <value>The client user id.</value>
+        [JsonProperty("client_user_id")]
+        public string ClientUserId { get; set; }
+    }
+}

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -1,0 +1,105 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+    /// <summary>
+    /// Represents a request for plaid's '/link/token/create' endpoint. Create a link_token.
+    /// </summary>
+    /// <seealso cref="Acklann.Plaid.SerializableContent" />
+    public class CreateLinkTokenRequest : SerializableContent
+    {
+        /// <summary>
+        /// Gets or sets the client identifier.
+        /// </summary>
+        /// <value>The client identifier.</value>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the secret.
+        /// </summary>
+        /// <value>The secret.</value>
+        [JsonProperty("secret")]
+        public string Secret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client name.
+        /// </summary>
+        /// <value>The client name.</value>
+        [JsonProperty("client_name")]
+        public string ClientName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the language.
+        /// </summary>
+        /// <value>The language.</value>
+        [JsonProperty("language")]
+        public string Language { get; set; }
+
+        /// <summary>
+        /// Gets or sets the country codes.
+        /// </summary>
+        /// <value>The country codes.</value>
+        [JsonProperty("country_codes")]
+        public string[] CountryCodes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user.
+        /// </summary>
+        /// <value>The user.</value>
+        [JsonProperty("user")]
+        public UserInfo User { get; set; }
+
+        /// <summary>
+        /// Gets or sets the products.
+        /// </summary>
+        /// <value>The products.</value>
+        [JsonProperty("products")]
+        public string[] Products { get; set; }
+
+        /// <summary>
+        /// Gets or sets the webhook.
+        /// </summary>
+        /// <value>The webhook.</value>
+        [JsonProperty("webhook")]
+        public string Webhook { get; set; }
+
+        /// <summary>
+        /// Gets or sets the link customization name.
+        /// </summary>
+        /// <value>The link customization name.</value>
+        [JsonProperty("link_customization_name")]
+        public string LinkCustomizationName { get; set; }
+
+        // TODO: account filters
+
+        /// <summary>
+        /// Gets or sets the access_token.
+        /// </summary>
+        /// <value>The access token.</value>
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the redirect uri.
+        /// </summary>
+        /// <value>The redirect uri.</value>
+        [JsonProperty("redirect_uri")]
+        public string RedirectUri { get; set; }
+
+        // TODO: payment initiation
+
+        /// <summary>
+        /// Represents an <see cref="Entity.User"/> metadata.
+        /// </summary>
+        public struct UserInfo
+        {
+            /// <summary>
+            /// Gets or sets the <see cref="Entity.User"/> client user id.
+            /// </summary>
+            /// <value>The client user id.</value>
+            [JsonProperty("client_user_id")]
+            public string ClientUserId { get; set; }
+        }
+    }
+}

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Acklann.Plaid.Management
 {
@@ -71,7 +72,12 @@ namespace Acklann.Plaid.Management
         [JsonProperty("link_customization_name")]
         public string LinkCustomizationName { get; set; }
 
-        // TODO: account filters
+        /// <summary>
+        /// Gets or sets the account filters.
+        /// </summary>
+        /// <value>The account filters.</value>
+        [JsonProperty("account_filters")]
+        public Dictionary<string, List<string>> AccountFilters { get; set; }
 
         /// <summary>
         /// Gets or sets the access_token.
@@ -87,7 +93,13 @@ namespace Acklann.Plaid.Management
         [JsonProperty("redirect_uri")]
         public string RedirectUri { get; set; }
 
-        // TODO: payment initiation
+        /// <summary>
+        /// Gets or sets the payment initiation.
+        /// </summary>
+        /// <value>The payment initiation.</value>
+        /// <remarks>Payment initiation still needs to be typed and fully implemented.</remarks>
+        [JsonProperty("payment_initiation")]
+        public object PaymentInitiation { get; set; }
 
         /// <summary>
         /// Represents an <see cref="Entity.User"/> metadata.

--- a/src/Plaid/Management/CreateLinkTokenResponse.cs
+++ b/src/Plaid/Management/CreateLinkTokenResponse.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+    /// <summary>
+    /// Represents a response from plaid's '/link/token/create' endpoint. Create a link_token.
+    /// </summary>
+    /// <seealso cref="Acklann.Plaid.ResponseBase" />
+    public class CreateLinkTokenResponse : ResponseBase
+    {
+        /// <summary>
+        /// Gets or sets the link token.
+        /// </summary>
+        /// <value>The link token.</value>
+        [JsonProperty("link_token")]
+        public string LinkToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration.
+        /// </summary>
+        /// <value>The expiration.</value>
+        [JsonProperty("expiration")]
+        public string Expiration { get; set; }
+    }
+}

--- a/src/Plaid/PlaidClient.cs
+++ b/src/Plaid/PlaidClient.cs
@@ -91,6 +91,16 @@ namespace Acklann.Plaid
         }
 
         /// <summary>
+        /// Creates a Link link_token.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public Task<Management.CreateLinkTokenResponse> CreateLinkToken(Management.CreateLinkTokenRequest request)
+        {
+            return PostAsync<Management.CreateLinkTokenResponse>("link/token/create", request);
+        }
+
+        /// <summary>
         /// Exchanges a Link public_token for an API access_token.
         /// </summary>
         /// <param name="request">The request.</param>

--- a/tests/Plaid.MSTest/Helper.cs
+++ b/tests/Plaid.MSTest/Helper.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
@@ -29,6 +30,21 @@ namespace Acklann.Plaid
             PropertyInfo[] properties = request.GetType().GetTypeInfo().GetRuntimeProperties().ToArray();
             setProperty(nameof(Institution.SearchRequest.PublicKey), PublicKey);
             setProperty(nameof(RequestBase.AccessToken), AccessToken);
+            setProperty(nameof(RequestBase.ClientId), ClientId);
+            setProperty(nameof(RequestBase.Secret), Secret);
+            return request;
+
+            void setProperty(string name, object value)
+            {
+                PropertyInfo target = properties.FirstOrDefault(p => p.Name == name);
+                if (target != null) target.SetValue(request, value);
+            }
+        }
+
+        public static TRequest UseDefaultsWithNoAccessToken<TRequest>(this TRequest request)
+        {
+            PropertyInfo[] properties = request.GetType().GetTypeInfo().GetRuntimeProperties().ToArray();
+            setProperty(nameof(Institution.SearchRequest.PublicKey), PublicKey);
             setProperty(nameof(RequestBase.ClientId), ClientId);
             setProperty(nameof(RequestBase.Secret), Secret);
             return request;

--- a/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
+++ b/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
@@ -226,24 +226,18 @@ namespace Acklann.Plaid.Tests
         public void CreateLinkToken_should_retrieve_link_token_and_expiration()
         {
             // Arrange
-            string[] countryCodes = new string[] { "US" };
-
-            var user = new UserInfo
-            {
-                ClientUserId = Guid.NewGuid().ToString()
-            };
-
-            string[] products = new string[] { "auth" };
-
             var sut = new PlaidClient(Environment.Sandbox);
             var request = new Management.CreateLinkTokenRequest()
             {
                 ClientName = "Example Client Name",
                 Language = "en",
-                CountryCodes = countryCodes,
-                User = user,
-                Products = products
-            }.UseDefaults();
+                CountryCodes = new string[] { "US" },
+                User = new UserInfo
+                {
+                    ClientUserId = Guid.NewGuid().ToString()
+                },
+                Products = new string[] { "auth" }
+            }.UseDefaultsWithNoAccessToken();
 
             // Act
             var result = sut.CreateLinkToken(request).Result;

--- a/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
+++ b/tests/Plaid.MSTest/Tests/PlaidClientTest.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Shouldly;
+using System;
+using static Acklann.Plaid.Management.CreateLinkTokenRequest;
 
 namespace Acklann.Plaid.Tests
 {
@@ -218,6 +220,39 @@ namespace Acklann.Plaid.Tests
             result.RequestId.ShouldNotBeNullOrEmpty();
             result.Income.Streams.Length.ShouldBeGreaterThan(0);
             result.Income.LastYearIncome.ShouldBeGreaterThan(0);
+        }
+
+        [TestMethod]
+        public void CreateLinkToken_should_retrieve_link_token_and_expiration()
+        {
+            // Arrange
+            string[] countryCodes = new string[] { "US" };
+
+            var user = new UserInfo
+            {
+                ClientUserId = Guid.NewGuid().ToString()
+            };
+
+            string[] products = new string[] { "auth" };
+
+            var sut = new PlaidClient(Environment.Sandbox);
+            var request = new Management.CreateLinkTokenRequest()
+            {
+                ClientName = "Example Client Name",
+                Language = "en",
+                CountryCodes = countryCodes,
+                User = user,
+                Products = products
+            }.UseDefaults();
+
+            // Act
+            var result = sut.CreateLinkToken(request).Result;
+
+            // Assert
+            result.IsSuccessStatusCode.ShouldBeTrue();
+            result.RequestId.ShouldNotBeNullOrEmpty();
+            result.LinkToken.ShouldNotBeNullOrEmpty();
+            result.Expiration.ShouldNotBeNullOrEmpty();
         }
     }
 }


### PR DESCRIPTION
Addresses #25. Implements the ability to create a link_token using Plaid's "link/token/create" endpoint.