### PR TITLE
Added missing fields to Item response, Transaction entity

### DIFF
--- a/src/Plaid/Entity/Transaction.cs
+++ b/src/Plaid/Entity/Transaction.cs
@@ -54,6 +54,12 @@ namespace Acklann.Plaid.Entity
         public string TransactionType { get; set; }
 
         /// <summary>
+        /// The channel used to make a payment. Possible values are: online, in store, other. This field will replace the transaction_type field
+        /// </summary>
+        [JsonProperty("payment_channel")]
+        public string PaymentChannel { get; set; }
+
+        /// <summary>
         /// Gets or sets the settled dollar value. Positive values when money moves out of the account; negative values when money moves in. For example, purchases are positive; credit card payments, direct deposits, refunds are negative.
         /// </summary>
         /// <value>The amount.</value>
@@ -87,6 +93,13 @@ namespace Acklann.Plaid.Entity
         /// <remarks>For pending transactions, Plaid returns the date the transaction occurred; for posted transactions, Plaid returns the date the transaction posts.</remarks>
         [JsonProperty("date")]
         public DateTime Date { get; set; }
+
+        /// <summary>
+        /// Gets or sets the date that the transaction was authorized.
+        /// </summary>
+        /// <value>The transaction authorized date. Optional</value>
+        [JsonProperty("authorized_date")]
+        public DateTime? AuthorizedDate { get; set; }
 
         /// <summary>
         /// Gets or sets the information of the merchant's location. Typically <c>null</c>.
@@ -182,6 +195,13 @@ namespace Acklann.Plaid.Entity
             /// <value>The longitude.</value>
             [JsonProperty("lon")]
             public double? Longitude { get; set; }
+
+            /// <summary>
+            /// Gets or sets the alpha-2 country code where the transaction occurred.
+            /// </summary>
+            /// <value>Country code</value>
+            [JsonProperty("country")]
+            public string Country { get; set; }
 
             /// <summary>
             /// Gets or sets the store number.

--- a/src/Plaid/Management/GetItemResponse.cs
+++ b/src/Plaid/Management/GetItemResponse.cs
@@ -1,4 +1,7 @@
-﻿namespace Acklann.Plaid.Management
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Acklann.Plaid.Management
 {
     /// <summary>
     /// Represents a response from plaid's '/item/get' endpoint. The POST /item/get endpoint returns information about the status of an <see cref="Entity.Item"/>.
@@ -11,5 +14,66 @@
         /// </summary>
         /// <value>The item.</value>
         public Entity.Item Item { get; set; }
+
+        /// <summary>
+        ///  Gets or sets Last transaction, webhook statuses of the Item
+        /// </summary>
+        /// <value>The Item status info.</value>
+        [JsonProperty("status")]
+        public ItemStatus Status { get; set; }
+
+        /// <summary>
+        /// Information about the last transaction, webhook statuses of the Item.
+        /// </summary>
+        public partial class ItemStatus
+        {
+            /// <summary>
+            /// Gets or sets the timestamps of the last successful and failed transactions update for the Item.
+            /// </summary>
+            [JsonProperty("transactions")]
+            public Transactions Transactions { get; set; }
+
+            /// <summary>
+            /// Gets or sets the information about the last webhook fired for the Item.
+            /// </summary>
+            [JsonProperty("last_webhook")]
+            public LastWebhook LastWebhook { get; set; }
+        }
+
+        /// <summary>
+        /// Information about the last webhook fired for the Item.
+        /// </summary>
+        public partial class LastWebhook
+        {
+            /// <summary>
+            /// Timestamp of when the webhook was fired.
+            /// </summary>
+            [JsonProperty("sent_at")]
+            public DateTime? SentAt { get; set; }
+
+            /// <summary>
+            /// The last webhook code sent
+            /// </summary>
+            [JsonProperty("code_sent")]
+            public string CodeSent { get; set; }
+        }
+
+        /// <summary>
+        /// Information about the last successful and failed transactions update for the Item.
+        /// </summary>
+        public partial class Transactions
+        {
+            /// <summary>
+            /// Timestamp of the last successful transactions update for the Item.
+            /// </summary>
+            [JsonProperty("last_successful_update")]
+            public DateTime? LastSuccessfulUpdate { get; set; }
+
+            /// <summary>
+            /// Timestamp of the last failed transactions update for the Item.
+            /// </summary>
+            [JsonProperty("last_failed_update")]
+            public DateTime? LastFailedUpdate { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Added missing fields to Plaid response objects.

1. Below fields are missing from _Entity.Transaction_ object. 

- 'Location/country' 
- 'authorized_date' 

2. Below fields are missing from Item/get response

- status