### PR TITLE
Issue #19 Fix - Don't include access token on ExchangeTokenRequest

### DIFF
--- a/src/Plaid/Management/ExchangeTokenRequest.cs
+++ b/src/Plaid/Management/ExchangeTokenRequest.cs
@@ -6,13 +6,13 @@ namespace Acklann.Plaid.Management
 	/// Represents a request for plaid's '/item/public_token/exchange' endpoint. Exchange a Link public_token for an API access_token.
 	/// </summary>
 	/// <seealso cref="Acklann.Plaid.SerializableContent" />
-	public class ExchangeTokenRequest : RequestBase
+	public class ExchangeTokenRequest : SerializableContent
 	{
-		/// <summary>
-		/// Gets or sets the public_token.
-		/// </summary>
-		/// <value>The public token.</value>
-		[JsonProperty("public_token")]
-		public string PublicToken { get; set; }
+		[JsonProperty("secret")]
+        public string Secret { get; set; }
+        [JsonProperty("public_token")]
+        public string PublicToken { get; set; }
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
 	}
 }


### PR DESCRIPTION
This fixes issue #19 

We can't inherit from RequestBase because that includes access token on the request. This results in a bad request.

This is the fix that I got working when I was adding your library to my application.

Thanks.