### PR TITLE
Allows for pre-matched RUX (Returning User Experience)

### DIFF
--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -13,5 +13,19 @@ namespace Acklann.Plaid.Entity
         /// <value>The client user id.</value>
         [JsonProperty("client_user_id")]
         public string ClientUserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client phone number.
+        /// </summary>
+        /// <value>The client phone number.</value>
+        [JsonProperty("phone_number")]
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the verification time of the client phone number.
+        /// </summary>
+        /// <value>The verification time of the client phone number.</value>
+        [JsonProperty("phone_number_verified_time")]
+        public string PhoneNumberVerifiedTime { get; set; }
     }
 }

--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -41,5 +41,12 @@ namespace Acklann.Plaid.Entity
 		/// <value>The client email address.</value>
 		[JsonProperty("email_address")]
 		public string EmailAddress { get; set; }
+
+		/// <summary>
+		/// Gets or sets the verification time of the client email address.
+		/// </summary>
+		/// <value>The verification time of the client email address.</value>
+		[JsonProperty("email_address_verified_time")]
+		public string EmailAddressVerifiedTime { get; set; }
 	}
 }

--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -14,39 +14,39 @@ namespace Acklann.Plaid.Entity
         [JsonProperty("client_user_id")]
         public string ClientUserId { get; set; }
 
-		/// <summary>
-		/// Gets or sets the client legal name.
-		/// </summary>
-		/// <value>The client legal name.</value>
-		[JsonProperty("legal_name")]
-		public string LegalName { get; set; }
+	/// <summary>
+	/// Gets or sets the client legal name.
+	/// </summary>
+	/// <value>The client legal name.</value>
+	[JsonProperty("legal_name")]
+	public string LegalName { get; set; }
 
-		/// <summary>
-		/// Gets or sets the client phone number.
-		/// </summary>
-		/// <value>The client phone number.</value>
-		[JsonProperty("phone_number")]
-        public string PhoneNumber { get; set; }
+	/// <summary>
+	/// Gets or sets the client phone number.
+	/// </summary>
+	/// <value>The client phone number.</value>
+	[JsonProperty("phone_number")]
+	public string PhoneNumber { get; set; }
 
-        /// <summary>
-        /// Gets or sets the verification time of the client phone number.
-        /// </summary>
-        /// <value>The verification time of the client phone number.</value>
-        [JsonProperty("phone_number_verified_time")]
-        public string PhoneNumberVerifiedTime { get; set; }
+	/// <summary>
+	/// Gets or sets the verification time of the client phone number.
+	/// </summary>
+	/// <value>The verification time of the client phone number.</value>
+	[JsonProperty("phone_number_verified_time")]
+	public string PhoneNumberVerifiedTime { get; set; }
 
-		/// <summary>
-		/// Gets or sets the client email address.
-		/// </summary>
-		/// <value>The client email address.</value>
-		[JsonProperty("email_address")]
-		public string EmailAddress { get; set; }
+	/// <summary>
+	/// Gets or sets the client email address.
+	/// </summary>
+	/// <value>The client email address.</value>
+	[JsonProperty("email_address")]
+	public string EmailAddress { get; set; }
 
-		/// <summary>
-		/// Gets or sets the verification time of the client email address.
-		/// </summary>
-		/// <value>The verification time of the client email address.</value>
-		[JsonProperty("email_address_verified_time")]
-		public string EmailAddressVerifiedTime { get; set; }
-	}
+	/// <summary>
+	/// Gets or sets the verification time of the client email address.
+	/// </summary>
+	/// <value>The verification time of the client email address.</value>
+	[JsonProperty("email_address_verified_time")]
+	public string EmailAddressVerifiedTime { get; set; }
+    }
 }

--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -34,5 +34,12 @@ namespace Acklann.Plaid.Entity
         /// <value>The verification time of the client phone number.</value>
         [JsonProperty("phone_number_verified_time")]
         public string PhoneNumberVerifiedTime { get; set; }
-    }
+
+		/// <summary>
+		/// Gets or sets the client email address.
+		/// </summary>
+		/// <value>The client email address.</value>
+		[JsonProperty("email_address")]
+		public string EmailAddress { get; set; }
+	}
 }

--- a/src/Plaid/Entity/User.cs
+++ b/src/Plaid/Entity/User.cs
@@ -14,11 +14,18 @@ namespace Acklann.Plaid.Entity
         [JsonProperty("client_user_id")]
         public string ClientUserId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the client phone number.
-        /// </summary>
-        /// <value>The client phone number.</value>
-        [JsonProperty("phone_number")]
+		/// <summary>
+		/// Gets or sets the client legal name.
+		/// </summary>
+		/// <value>The client legal name.</value>
+		[JsonProperty("legal_name")]
+		public string LegalName { get; set; }
+
+		/// <summary>
+		/// Gets or sets the client phone number.
+		/// </summary>
+		/// <value>The client phone number.</value>
+		[JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
 
         /// <summary>

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -134,6 +134,13 @@ namespace Acklann.Plaid.Management
 			/// <value>The client email address.</value>
 			[JsonProperty("email_address")]
 			public string EmailAddress { get; set; }
+
+			/// <summary>
+			/// Gets or sets the verification time of the client email address.
+			/// </summary>
+			/// <value>The verification time of the client email address.</value>
+			[JsonProperty("email_address_verified_time")]
+			public string EmailAddressVerifiedTime { get; set; }
 		}
 	}
 }

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -127,6 +127,13 @@ namespace Acklann.Plaid.Management
 			/// <value>The verification time of the client phone number.</value>
 			[JsonProperty("phone_number_verified_time")]
 			public string PhoneNumberVerifiedTime { get; set; }
+
+			/// <summary>
+			/// Gets or sets the client email address.
+			/// </summary>
+			/// <value>The client email address.</value>
+			[JsonProperty("email_address")]
+			public string EmailAddress { get; set; }
 		}
 	}
 }

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -108,6 +108,13 @@ namespace Acklann.Plaid.Management
 			public string ClientUserId { get; set; }
 
 			/// <summary>
+			/// Gets or sets the client legal name.
+			/// </summary>
+			/// <value>The client legal name.</value>
+			[JsonProperty("legal_name")]
+			public string LegalName { get; set; }
+
+			/// <summary>
 			/// Gets or sets the client phone number.
 			/// </summary>
 			/// <value>The client phone number.</value>

--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -106,6 +106,20 @@ namespace Acklann.Plaid.Management
 			/// <value>The client user id.</value>
 			[JsonProperty("client_user_id")]
 			public string ClientUserId { get; set; }
+
+			/// <summary>
+			/// Gets or sets the client phone number.
+			/// </summary>
+			/// <value>The client phone number.</value>
+			[JsonProperty("phone_number")]
+			public string PhoneNumber { get; set; }
+
+			/// <summary>
+			/// Gets or sets the verification time of the client phone number.
+			/// </summary>
+			/// <value>The verification time of the client phone number.</value>
+			[JsonProperty("phone_number_verified_time")]
+			public string PhoneNumberVerifiedTime { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
Adds `LegalName`, `PhoneNumber`, `PhoneNumberVerifiedTime`, `EmailAddress`, and `EmailAddressVerifiedTime` to `User` and `CreateLinkTokenRequest` so that users who have already been verified through a financial institution can proceed through Plaid's new Returning User Experience.

See the related docs here: https://plaid.com/docs/link/returning-user and https://plaid.com/docs/api/tokens/#linktokencreate