### PR TITLE
Add support for processor/token/create endpoint

### DIFF
--- a/src/Plaid/Management/CreateProcessorTokenRequest.cs
+++ b/src/Plaid/Management/CreateProcessorTokenRequest.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+	/// <summary>
+	/// Represents a request for plaid's '/processor/token/create' endpoint. Create a processor_token from an access_token.
+	/// </summary>
+	/// <seealso cref="Acklann.Plaid.SerializableContent" />
+	public class CreateProcessorTokenRequest : SerializableContent
+	{
+		/// <summary>
+		/// Gets or sets the client identifier.
+		/// </summary>
+		/// <value>The client identifier.</value>
+		[JsonProperty("client_id")]
+		public string ClientId { get; set; }
+
+		/// <summary>
+		/// Gets or sets the secret.
+		/// </summary>
+		/// <value>The secret.</value>
+		[JsonProperty("secret")]
+		public string Secret { get; set; }
+
+		/// <summary>
+		/// Gets or sets the access_token.
+		/// </summary>
+		/// <value>The access token.</value>
+		[JsonProperty("access_token")]
+		public string AccessToken { get; set; }
+
+		/// <summary>
+		/// Gets or sets the client_id.
+		/// </summary>
+		/// <value>The account identifier.</value>
+		[JsonProperty("account_id")]
+		public string AccountId { get; set; }
+
+		/// <summary>
+		/// Gets or sets the client_id.
+		/// </summary>
+		/// <value>The processor you are integrating with.</value>
+		[JsonProperty("processor")]
+		public string Processor { get; set; }
+	}
+}

--- a/src/Plaid/Management/CreateProcessorTokenResponse.cs
+++ b/src/Plaid/Management/CreateProcessorTokenResponse.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace Acklann.Plaid.Management
+{
+	/// <summary>
+	/// Represents a response from plaid's '/processor/token/create' endpoint. Create a token suitable for sending to one of Plaid's partners to enable integrations.
+	/// </summary>
+	/// <seealso cref="Acklann.Plaid.ResponseBase" />
+	public class CreateProcessorTokenResponse : ResponseBase
+	{
+		/// <summary>
+		/// Gets or sets the processor token.
+		/// </summary>
+		/// <value>The processor token.</value>
+		[JsonProperty("processor_token")]
+		public string ProcessorToken { get; set; }
+	}
+}

--- a/src/Plaid/PlaidClient.cs
+++ b/src/Plaid/PlaidClient.cs
@@ -148,6 +148,16 @@ namespace Acklann.Plaid
 		}
 
 		/// <summary>
+		/// Exchanges an access_token for an API Processor_token.
+		/// </summary>
+		/// <param name="request">The request.</param>
+		/// <returns>Task&lt;Management.CreateProcessorTokenResponse&gt;.</returns>
+		public Task<Management.CreateProcessorTokenResponse> CreateProcessorTokenAsync(Management.CreateProcessorTokenRequest request)
+		{
+			return PostAsync<Management.CreateProcessorTokenResponse>("processor/token/create", request);
+		}
+
+		/// <summary>
 		/// Creates a Link link_token.
 		/// </summary>
 		/// <param name="request"></param>


### PR DESCRIPTION
Adds support for https://plaid.com/docs/api/processors/#processortokencreate

With this change this version of the Plaid.NET integration should support processor tokens as well (with exclusion of some stripe-specific behavior?)

These changes were originally made in our org's repo https://github.com/LN-Zap/Plaid.NET/commit/facc05ac22f8d4aff3e92afcc428661c15159aeb but we'd like to become upstream so we can move back to upstream for our purposes.